### PR TITLE
Translate extension text to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,33 @@
 # Focus Blocker
 
-Extensão para Chrome que bloqueia sites que distraem e ajuda a manter o foco.
+Chrome extension that blocks distracting sites and helps maintain focus.
 
-## Recursos
+## Features
 
-- Bloqueio de sites por palavra‑chave usando a API `declarativeNetRequest`.
-- Página de configurações para adicionar ou remover sites bloqueados.
-- Página de bloqueio com estatísticas diárias e frases motivacionais.
-- Dados armazenados localmente usando `chrome.storage`.
+- Site blocking by keyword using the `declarativeNetRequest` API.
+- Settings page to add or remove blocked sites.
+- Block page with daily statistics and motivational quotes.
+- Data stored locally using `chrome.storage`.
 
-## Instalação
+## Installation
 
-1. Baixe ou clone este repositório.
-2. No Chrome, acesse `chrome://extensions`.
-3. Ative o **Modo do desenvolvedor**.
-4. Clique em **Carregar sem compactação** e selecione a pasta do projeto.
+1. Download or clone this repository.
+2. In Chrome, go to `chrome://extensions`.
+3. Enable **Developer mode**.
+4. Click **Load unpacked** and select the project folder.
 
-## Uso
+## Usage
 
-- Para bloquear um site, abra a página de opções da extensão e adicione o endereço desejado.
-- Ao tentar acessar um site bloqueado, a extensão redireciona para uma página de aviso com estatísticas e mensagens motivacionais.
+- To block a site, open the extension options page and add the desired address.
+- When attempting to access a blocked site, the extension redirects to a warning page with statistics and motivational messages.
 
-## Estrutura do projeto
+## Project Structure
 
-- `manifest.json`: definições da extensão.
-- `background.js`: gerenciamento dinâmico de regras de bloqueio.
-- `options/`: interface para configurar sites bloqueados.
-- `blocked/`: página exibida quando um site é bloqueado.
+- `manifest.json`: extension definitions.
+- `background.js`: dynamic rule management.
+- `options/`: interface for configuring blocked sites.
+- `blocked/`: page displayed when a site is blocked.
 
-## Contribuições
+## Contributions
 
-Sinta‑se à vontade para abrir issues e pull requests com melhorias ou correções.
+Feel free to open issues and pull requests with improvements or fixes.

--- a/blocked/blocked.html
+++ b/blocked/blocked.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Acesso Bloqueado - Focus Blocker</title>
+    <title>Access Blocked - Focus Blocker</title>
     <link rel="stylesheet" href="styles.css" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
@@ -27,32 +27,32 @@
           </svg>
         </div>
 
-        <h1 class="title">Acesso Bloqueado</h1>
+        <h1 class="title">Access Blocked</h1>
         <p class="subtitle">
-          Este site foi bloqueado para ajudar você a manter o foco
+          This site was blocked to help you stay focused
         </p>
 
         <div class="blocked-url">
-          <span id="blockedSite">site-bloqueado.com</span>
+          <span id="blockedSite">blocked-site.com</span>
         </div>
 
         <div class="stats">
           <div class="stat">
             <span class="stat-number" id="blocksToday">0</span>
-            <span class="stat-label">bloqueios hoje</span>
+            <span class="stat-label">blocks today</span>
           </div>
         </div>
 
         <div class="quote">
           <p id="motivationalText">
-            "O foco é a chave para transformar sonhos em realidade."
+            "Focus is the key to turning dreams into reality."
           </p>
         </div>
 
         <div class="actions">
-          <button class="btn btn-primary" onclick="goBack()">Voltar</button>
+          <button class="btn btn-primary" onclick="goBack()">Go Back</button>
           <button class="btn btn-secondary" onclick="openSettings()">
-            Configurações
+            Settings
           </button>
         </div>
 

--- a/blocked/script.js
+++ b/blocked/script.js
@@ -17,13 +17,13 @@ class BlockedPage {
 
     try {
       const urlParams = new URLSearchParams(window.location.search);
-      const blockedSite =
-        urlParams.get("site") ||
-        window.location.hostname ||
-        "site-bloqueado.com";
-      blockedSiteElement.textContent = blockedSite;
-    } catch (error) {
-      blockedSiteElement.textContent = "site-bloqueado.com";
+        const blockedSite =
+          urlParams.get("site") ||
+          window.location.hostname ||
+          "blocked-site.com";
+        blockedSiteElement.textContent = blockedSite;
+      } catch (error) {
+        blockedSiteElement.textContent = "blocked-site.com";
     }
   }
 
@@ -52,7 +52,7 @@ class BlockedPage {
       await window.chrome.storage.local.set({ blockedStats: stats });
       this.displayStats(stats[today]);
     } catch (error) {
-      console.error("Erro ao atualizar estatísticas:", error);
+        console.error("Error updating statistics:", error);
       this.displayStats({ blocks: 1, timeBlocked: 5 });
     }
   }
@@ -87,7 +87,7 @@ class BlockedPage {
   }
 }
 
-// Funções globais para os botões
+  // Global functions for buttons
 function goBack() {
   if (window.history.length > 1) {
     window.history.back();
@@ -100,14 +100,14 @@ function openSettings() {
   try {
     window.chrome.runtime.openOptionsPage();
   } catch (error) {
-    console.error("Não foi possível abrir as configurações:", error);
+    console.error("Could not open settings:", error);
     alert(
-      "Para acessar as configurações, clique no ícone da extensão na barra de ferramentas."
+      "To access the settings, click the extension icon in the toolbar."
     );
   }
 }
 
-// Inicializar
+  // Initialize
 document.addEventListener("DOMContentLoaded", () => {
   new BlockedPage();
 });

--- a/blocked/styles.css
+++ b/blocked/styles.css
@@ -306,7 +306,7 @@ body {
   }
 }
 
-/* Altura mínima para telas muito pequenas */
+/* Minimum height for very small screens */
 @media (max-height: 600px) {
   .content {
     position: static;

--- a/blocked/verses.js
+++ b/blocked/verses.js
@@ -1,5 +1,5 @@
-// Lista de versículos exibidos na página de bloqueio
-// Mantida como variável global para uso em script.js
+// List of verses displayed on the block page
+// Kept as a global variable for use in script.js
 window.motivationalQuotes = [
   'Ephesians 2:8-9 — "For by grace you have been saved through faith, and this is not from yourselves, it is the gift of God; not by works, so that no one can boast."',
   'John 3:16 — "For God so loved the world that He gave His one and only Son, that whoever believes in Him shall not perish but have eternal life."',

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Focus Blocker",
   "version": "1.3",
-  "description": "Bloqueia sites para manter o foco e a disciplina.",
+  "description": "Blocks sites to maintain focus and discipline.",
   "permissions": ["storage", "declarativeNetRequest"],
   "host_permissions": ["<all_urls>"],
   "background": {

--- a/options/options.html
+++ b/options/options.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="pt-BR">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -27,7 +27,7 @@
           </svg>
           <h1>Focus Blocker</h1>
         </div>
-        <p class="subtitle">Mantenha o foco bloqueando sites que distraem</p>
+        <p class="subtitle">Stay focused by blocking distracting websites</p>
       </div>
 
       <div class="main-section">
@@ -36,17 +36,17 @@
             <input
               type="text"
               id="urlInput"
-              placeholder="Digite o site para bloquear (ex: youtube.com)"
+              placeholder="Enter a site to block (e.g., youtube.com)"
               autocomplete="off"
               spellcheck="false"
             />
-            <button type="submit" class="add-btn" id="addBtn">Adicionar</button>
+            <button type="submit" class="add-btn" id="addBtn">Add</button>
           </div>
         </form>
 
         <div class="blocked-section">
           <div class="section-title">
-            <span class="count" id="blockedCount">0</span> sites bloqueados
+            <span class="count" id="blockedCount">0</span> blocked sites
           </div>
 
           <div class="empty-state" id="emptyState">
@@ -62,11 +62,11 @@
               <path d="M12 8v8" />
               <path d="M8 12h8" />
             </svg>
-            <p>Nenhum site bloqueado ainda</p>
+            <p>No blocked sites yet</p>
           </div>
 
           <div class="blocked-list" id="blockedList">
-            <!-- Sites bloqueados serão inseridos aqui -->
+            <!-- Blocked sites will be inserted here -->
           </div>
         </div>
       </div>

--- a/options/options.js
+++ b/options/options.js
@@ -44,7 +44,7 @@ class FocusBlockerOptions {
     const keyword = this.normalizeUrl(this.urlInput.value);
 
     if (!keyword) {
-      this.showToast("Digite um site para bloquear", "warning");
+      this.showToast("Enter a site to block", "warning");
       return;
     }
 
@@ -58,9 +58,9 @@ class FocusBlockerOptions {
       this.blockedKeywords = blockedKeywords;
       this.updateUI();
       this.urlInput.value = "";
-      this.showToast(`${keyword} foi bloqueado`, "success");
+      this.showToast(`${keyword} was blocked`, "success");
     } else {
-      this.showToast("Este site já está bloqueado", "warning");
+      this.showToast("This site is already blocked", "warning");
     }
 
     this.setLoading(false);
@@ -76,12 +76,12 @@ class FocusBlockerOptions {
 
     this.blockedKeywords = blockedKeywords;
     this.updateUI();
-    this.showToast(`${keyword} foi desbloqueado`, "success");
+    this.showToast(`${keyword} was unblocked`, "success");
   }
 
   setLoading(loading) {
     this.addBtn.disabled = loading;
-    this.addBtn.textContent = loading ? "Adicionando..." : "Adicionar";
+    this.addBtn.textContent = loading ? "Adding..." : "Add";
   }
 
   updateUI() {
@@ -105,7 +105,7 @@ class FocusBlockerOptions {
 
     div.innerHTML = `
       <div class="blocked-item-url">${item}</div>
-      <button class="remove-btn" title="Remover">
+      <button class="remove-btn" title="Remove">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
           <path d="M18 6L6 18"/>
           <path d="M6 6l12 12"/>
@@ -164,7 +164,7 @@ class FocusBlockerOptions {
   }
 }
 
-// Inicializar
+// Initialize
 document.addEventListener("DOMContentLoaded", () => {
   window.focusBlocker = new FocusBlockerOptions();
 });


### PR DESCRIPTION
## Summary
- Convert documentation to English and describe features and usage clearly.
- Replace Portuguese UI strings on options and block pages with English equivalents.
- Localize JavaScript messages and comments to English throughout the extension.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e1f3c7618832283f888433824b4f2