### PR TITLE
Add extension icons to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,13 +3,27 @@
   "name": "Focus Blocker",
   "version": "1.3",
   "description": "Bloqueia sites para manter o foco e a disciplina.",
+  "icons": {
+    "16": "icons/icon16.png",
+    "24": "icons/icon24.png",
+    "32": "icons/icon32.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  },
   "permissions": ["storage", "declarativeNetRequest"],
   "host_permissions": ["<all_urls>"],
   "background": {
     "service_worker": "background.js"
   },
   "action": {
-    "default_popup": "options/options.html"
+    "default_popup": "options/options.html",
+    "default_icon": {
+      "16": "icons/icon16.png",
+      "24": "icons/icon24.png",
+      "32": "icons/icon32.png",
+      "48": "icons/icon48.png",
+      "128": "icons/icon128.png"
+    }
   },
   "declarative_net_request": {
     "rule_resources": [


### PR DESCRIPTION
## Summary
- add multiple icon sizes to the manifest so the extension uses custom icons
- configure default action icon set

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e2034bcbc8322b896845e2878de68