### PR TITLE
Default to dark mode

### DIFF
--- a/src/blocked/blocked.html
+++ b/src/blocked/blocked.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="theme-color" content="#000000" />

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/theme-toggle/theme-toggle.js
+++ b/src/theme-toggle/theme-toggle.js
@@ -1,7 +1,11 @@
 class ThemeToggle {
   constructor() {
     this.toggleButton = document.getElementById("themeToggle");
-    this.currentTheme = this.getStoredTheme() || this.getSystemTheme();
+    this.currentTheme = this.getStoredTheme() || "dark";
+
+    if (!this.getStoredTheme()) {
+      this.setStoredTheme(this.currentTheme);
+    }
 
     this.init();
   }


### PR DESCRIPTION
## Summary
- start the extension in dark mode by default
- persist default theme so system changes don't override it
- pre-set dark theme attribute on options and blocked pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e2b8416b88322acfb8172ed2af4d7