### PR TITLE
fix: remove inline event handlers

### DIFF
--- a/src/options/options.js
+++ b/src/options/options.js
@@ -19,9 +19,9 @@ class FocusBlockerOptions {
   }
 
   bindEvents() {
-    this.addBtn.onclick = () => {
+    this.addBtn.addEventListener("click", () => {
       this.addUrl();
-    };
+    });
 
     this.addForm.addEventListener("submit", (e) => {
       e.preventDefault();
@@ -114,9 +114,9 @@ class FocusBlockerOptions {
     `;
 
     const removeBtn = div.querySelector(".remove-btn");
-    removeBtn.onclick = () => {
+    removeBtn.addEventListener("click", () => {
       this.removeUrl(index);
-    };
+    });
 
     return div;
   }


### PR DESCRIPTION
## Summary
- attach click handlers with addEventListener to avoid inline events and satisfy CSP

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e2d44b4a883229eaea11d3d0d8a11