### PR TITLE
Initialize theme before page load

### DIFF
--- a/src/blocked/blocked.html
+++ b/src/blocked/blocked.html
@@ -1,10 +1,32 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="theme-color" content="#000000" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blocked Page</title>
+    <script>
+      (function () {
+        try {
+          const storedTheme = localStorage.getItem("focus-blocker-theme");
+          const systemPrefersDark = window.matchMedia(
+            "(prefers-color-scheme: dark)"
+          ).matches;
+          const theme = storedTheme || (systemPrefersDark ? "dark" : "light");
+          if (theme === "dark") {
+            document.documentElement.setAttribute("data-theme", "dark");
+            const meta = document.querySelector('meta[name="theme-color"]');
+            if (meta) meta.setAttribute("content", "#000000");
+          } else {
+            document.documentElement.removeAttribute("data-theme");
+            const meta = document.querySelector('meta[name="theme-color"]');
+            if (meta) meta.setAttribute("content", "#ffffff");
+          }
+        } catch (e) {
+          console.warn("Theme init failed:", e);
+        }
+      })();
+    </script>
     <link rel="stylesheet" href="styles.css" />
     <link rel="stylesheet" href="../theme-toggle/theme-toggle.css" />
   </head>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -1,9 +1,27 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Focus Blocker</title>
+    <script>
+      (function () {
+        try {
+          const storedTheme = localStorage.getItem("focus-blocker-theme");
+          const systemPrefersDark = window.matchMedia(
+            "(prefers-color-scheme: dark)"
+          ).matches;
+          const theme = storedTheme || (systemPrefersDark ? "dark" : "light");
+          if (theme === "dark") {
+            document.documentElement.setAttribute("data-theme", "dark");
+          } else {
+            document.documentElement.removeAttribute("data-theme");
+          }
+        } catch (e) {
+          console.warn("Theme init failed:", e);
+        }
+      })();
+    </script>
     <link rel="stylesheet" href="styles.css" />
     <link rel="stylesheet" href="../theme-toggle/theme-toggle.css" />
     <link

--- a/src/theme-toggle/theme-toggle.js
+++ b/src/theme-toggle/theme-toggle.js
@@ -1,9 +1,10 @@
 class ThemeToggle {
   constructor() {
     this.toggleButton = document.getElementById("themeToggle");
-    this.currentTheme = this.getStoredTheme() || "dark";
+    this.currentTheme = this.getStoredTheme();
 
-    if (!this.getStoredTheme()) {
+    if (!this.currentTheme) {
+      this.currentTheme = this.getSystemTheme();
       this.setStoredTheme(this.currentTheme);
     }
 
@@ -64,6 +65,21 @@ class ThemeToggle {
   }
 
   applyTheme(theme) {
+    const currentAttr =
+      document.documentElement.getAttribute("data-theme") || "light";
+    if (currentAttr === theme) {
+      if (this.toggleButton) {
+        this.toggleButton.setAttribute(
+          "aria-label",
+          theme === "dark"
+            ? "Alternar para modo claro"
+            : "Alternar para modo escuro"
+        );
+      }
+      this.currentTheme = theme;
+      return;
+    }
+
     // Remove any existing theme attribute
     document.documentElement.removeAttribute("data-theme");
 
@@ -76,13 +92,16 @@ class ThemeToggle {
           "Alternar para modo claro"
         );
       }
-    } else {
-      if (this.toggleButton) {
-        this.toggleButton.setAttribute(
-          "aria-label",
-          "Alternar para modo escuro"
-        );
-      }
+    } else if (this.toggleButton) {
+      this.toggleButton.setAttribute(
+        "aria-label",
+        "Alternar para modo escuro"
+      );
+    }
+
+    const meta = document.querySelector('meta[name="theme-color"]');
+    if (meta) {
+      meta.setAttribute("content", theme === "dark" ? "#000000" : "#ffffff");
     }
 
     // Update current theme


### PR DESCRIPTION
## Summary
- Ensure options and blocked pages detect stored or system theme before loading styles to avoid flash of incorrect theme.
- Default ThemeToggle to system theme and skip re-applying the existing theme while updating meta theme-color.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e2db2cab48322b5a30c56ad2cebb6