### PR TITLE
refactor: externalize theme script and harden DOM updates

### DIFF
--- a/src/blocked/blocked.html
+++ b/src/blocked/blocked.html
@@ -5,28 +5,7 @@
     <meta name="theme-color" content="#000000" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Blocked Page</title>
-    <script>
-      (function () {
-        try {
-          const storedTheme = localStorage.getItem("focus-blocker-theme");
-          const systemPrefersDark = window.matchMedia(
-            "(prefers-color-scheme: dark)"
-          ).matches;
-          const theme = storedTheme || (systemPrefersDark ? "dark" : "light");
-          if (theme === "dark") {
-            document.documentElement.setAttribute("data-theme", "dark");
-            const meta = document.querySelector('meta[name="theme-color"]');
-            if (meta) meta.setAttribute("content", "#000000");
-          } else {
-            document.documentElement.removeAttribute("data-theme");
-            const meta = document.querySelector('meta[name="theme-color"]');
-            if (meta) meta.setAttribute("content", "#ffffff");
-          }
-        } catch (e) {
-          console.warn("Theme init failed:", e);
-        }
-      })();
-    </script>
+    <script src="../theme-toggle/theme-init.js"></script>
     <link rel="stylesheet" href="styles.css" />
     <link rel="stylesheet" href="../theme-toggle/theme-toggle.css" />
   </head>

--- a/src/blocked/script.js
+++ b/src/blocked/script.js
@@ -11,14 +11,15 @@ class BlockedPage {
     this.startStatsAnimation();
   }
 
-  displayRandomQuote() {
-    const quoteElement = document.getElementById("motivationalText");
-    const randomQuote =
-      this.motivationalQuotes[
-        Math.floor(Math.random() * this.motivationalQuotes.length)
-      ];
-    quoteElement.textContent = `"${randomQuote}"`;
-  }
+    displayRandomQuote() {
+      const quoteElement = document.getElementById("motivationalText");
+      if (!quoteElement) return;
+      const randomQuote =
+        this.motivationalQuotes[
+          Math.floor(Math.random() * this.motivationalQuotes.length)
+        ];
+      quoteElement.textContent = `"${randomQuote}"`;
+    }
 
   async updateStats() {
     try {

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -4,24 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Focus Blocker</title>
-    <script>
-      (function () {
-        try {
-          const storedTheme = localStorage.getItem("focus-blocker-theme");
-          const systemPrefersDark = window.matchMedia(
-            "(prefers-color-scheme: dark)"
-          ).matches;
-          const theme = storedTheme || (systemPrefersDark ? "dark" : "light");
-          if (theme === "dark") {
-            document.documentElement.setAttribute("data-theme", "dark");
-          } else {
-            document.documentElement.removeAttribute("data-theme");
-          }
-        } catch (e) {
-          console.warn("Theme init failed:", e);
-        }
-      })();
-    </script>
+      <script src="../theme-toggle/theme-init.js"></script>
     <link rel="stylesheet" href="styles.css" />
     <link rel="stylesheet" href="../theme-toggle/theme-toggle.css" />
     <link

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -79,10 +79,12 @@ class FocusBlockerOptions {
     showToast(this.toastContainer, `${keyword} was unblocked`, "success");
   }
 
-  setLoading(loading) {
-    this.addBtn.disabled = loading;
-    this.addBtn.textContent = loading ? "Adding..." : "Add";
-  }
+    setLoading(loading) {
+      if (this.addBtn) {
+        this.addBtn.disabled = loading;
+        this.addBtn.textContent = loading ? "Adding..." : "Add";
+      }
+    }
 
   updateUI() {
     this.updateBlockedList();
@@ -121,9 +123,11 @@ class FocusBlockerOptions {
     return div;
   }
 
-  updateCount() {
-    this.blockedCount.textContent = this.blockedKeywords.length;
-  }
+    updateCount() {
+      if (this.blockedCount) {
+        this.blockedCount.textContent = this.blockedKeywords.length;
+      }
+    }
 
   toggleEmptyState() {
     if (this.blockedKeywords.length === 0) {

--- a/src/theme-toggle/theme-init.js
+++ b/src/theme-toggle/theme-init.js
@@ -1,0 +1,18 @@
+(function () {
+  try {
+    const storedTheme = localStorage.getItem("focus-blocker-theme");
+    const systemPrefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const theme = storedTheme || (systemPrefersDark ? "dark" : "light");
+    if (theme === "dark") {
+      document.documentElement.setAttribute("data-theme", "dark");
+      const meta = document.querySelector('meta[name="theme-color"]');
+      if (meta) meta.setAttribute("content", "#000000");
+    } else {
+      document.documentElement.removeAttribute("data-theme");
+      const meta = document.querySelector('meta[name="theme-color"]');
+      if (meta) meta.setAttribute("content", "#ffffff");
+    }
+  } catch (e) {
+    console.warn("Theme init failed:", e);
+  }
+})();


### PR DESCRIPTION
## Summary
- move theme initialization to new `theme-init.js` and drop inline scripts for CSP compliance
- guard UI updates against missing DOM nodes to avoid runtime errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e321de90883229ffa7e0572ce58bd