### PR TITLE
Allow inline scripts via CSP

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -40,4 +40,8 @@
       "matches": ["<all_urls>"]
     }
   ]
+  ,
+  "content_security_policy": {
+    "extension_pages": "script-src 'self' 'unsafe-inline'; object-src 'self'"
+  }
 }


### PR DESCRIPTION
## Summary
- allow inline scripts via content security policy for extension pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e370fe4a0832298de3ef12f0cbcac