### PR TITLE
Harden extension security

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,8 +10,11 @@
     "48": "src/icons/icon48.png",
     "128": "src/icons/icon128.png"
   },
-  "permissions": ["storage", "declarativeNetRequest"],
-  "host_permissions": ["<all_urls>"],
+  "permissions": [
+    "storage",
+    "declarativeNetRequest",
+    "declarativeNetRequestWithHostAccess"
+  ],
   "background": {
     "service_worker": "src/background.js"
   },
@@ -37,11 +40,10 @@
   "web_accessible_resources": [
     {
       "resources": ["src/blocked/blocked.html"],
-      "matches": ["<all_urls>"]
+      "matches": ["https://*/*", "http://*/*"]
     }
-  ]
-  ,
+  ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'unsafe-inline'; object-src 'self'"
+    "extension_pages": "script-src 'self'; object-src 'self'"
   }
 }

--- a/src/background.js
+++ b/src/background.js
@@ -1,13 +1,29 @@
+const SECRET_KEY = "focus-blocker-key";
+
+function xor(str) {
+  let result = "";
+  for (let i = 0; i < str.length; i++) {
+    result += String.fromCharCode(
+      str.charCodeAt(i) ^ SECRET_KEY.charCodeAt(i % SECRET_KEY.length)
+    );
+  }
+  return result;
+}
+
+function decrypt(text) {
+  return xor(atob(text));
+}
+
 chrome.runtime.onInstalled.addListener(async () => {
   const { blockedKeywords = [] } = await chrome.storage.local.get(
     "blockedKeywords"
   );
-  updateRules(blockedKeywords);
+  updateRules(blockedKeywords.map(decrypt));
 });
 
 chrome.storage.onChanged.addListener(({ blockedKeywords }) => {
   if (blockedKeywords) {
-    updateRules(blockedKeywords.newValue);
+    updateRules(blockedKeywords.newValue.map(decrypt));
   }
 });
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -7,10 +7,6 @@
       <script src="../theme-toggle/theme-init.js"></script>
     <link rel="stylesheet" href="styles.css" />
     <link rel="stylesheet" href="../theme-toggle/theme-toggle.css" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
-      rel="stylesheet"
-    />
   </head>
   <body>
     <div class="container">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -48,6 +48,13 @@ class FocusBlockerOptions {
       return;
     }
 
+    const origin = `*://${keyword}/*`;
+    const granted = await chrome.permissions.request({ origins: [origin] });
+    if (!granted) {
+      showToast(this.toastContainer, "Permission denied", "warning");
+      return;
+    }
+
     this.setLoading(true);
 
     const blockedKeywords = await getBlockedKeywords();
@@ -73,6 +80,8 @@ class FocusBlockerOptions {
     const blockedKeywords = await getBlockedKeywords();
     blockedKeywords.splice(index, 1);
     await setBlockedKeywords(blockedKeywords);
+
+    chrome.permissions.remove({ origins: [`*://${keyword}/*`] });
 
     this.blockedKeywords = blockedKeywords;
     this.updateUI();
@@ -102,25 +111,40 @@ class FocusBlockerOptions {
   }
 
   createBlockedItemElement(item, index) {
-    const div = document.createElement("div");
-    div.className = "blocked-item";
+    const container = document.createElement("div");
+    container.className = "blocked-item";
 
-    div.innerHTML = `
-      <div class="blocked-item-url">${item}</div>
-      <button class="remove-btn" title="Remove">
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M18 6L6 18"/>
-          <path d="M6 6l12 12"/>
-        </svg>
-      </button>
-    `;
+    const urlDiv = document.createElement("div");
+    urlDiv.className = "blocked-item-url";
+    urlDiv.textContent = item;
+    container.appendChild(urlDiv);
 
-    const removeBtn = div.querySelector(".remove-btn");
-    removeBtn.addEventListener("click", () => {
+    const button = document.createElement("button");
+    button.className = "remove-btn";
+    button.title = "Remove";
+
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.setAttribute("width", "16");
+    svg.setAttribute("height", "16");
+    svg.setAttribute("viewBox", "0 0 24 24");
+    svg.setAttribute("fill", "none");
+    svg.setAttribute("stroke", "currentColor");
+    svg.setAttribute("stroke-width", "2");
+
+    const path1 = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path1.setAttribute("d", "M18 6L6 18");
+    const path2 = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path2.setAttribute("d", "M6 6l12 12");
+
+    svg.append(path1, path2);
+    button.appendChild(svg);
+    button.addEventListener("click", () => {
       this.removeUrl(index);
     });
 
-    return div;
+    container.appendChild(button);
+
+    return container;
   }
 
     updateCount() {

--- a/src/options/storage.js
+++ b/src/options/storage.js
@@ -1,8 +1,31 @@
+const SECRET_KEY = "focus-blocker-key";
+
+function xor(str) {
+  let result = "";
+  for (let i = 0; i < str.length; i++) {
+    result += String.fromCharCode(
+      str.charCodeAt(i) ^ SECRET_KEY.charCodeAt(i % SECRET_KEY.length)
+    );
+  }
+  return result;
+}
+
+function encrypt(text) {
+  return btoa(xor(text));
+}
+
+function decrypt(text) {
+  return xor(atob(text));
+}
+
 export async function getBlockedKeywords() {
-  const { blockedKeywords = [] } = await chrome.storage.local.get("blockedKeywords");
-  return blockedKeywords;
+  const { blockedKeywords = [] } = await chrome.storage.local.get(
+    "blockedKeywords"
+  );
+  return blockedKeywords.map(decrypt);
 }
 
 export function setBlockedKeywords(keywords) {
-  return chrome.storage.local.set({ blockedKeywords: keywords });
+  const encrypted = keywords.map(encrypt);
+  return chrome.storage.local.set({ blockedKeywords: encrypted });
 }

--- a/src/options/styles.css
+++ b/src/options/styles.css
@@ -22,8 +22,7 @@
 }
 
 body {
-  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: var(--background-secondary);
   color: var(--text-primary);
   line-height: 1.5;

--- a/src/options/utils.js
+++ b/src/options/utils.js
@@ -1,3 +1,13 @@
 export function normalizeUrl(url) {
-  return url.trim().toLowerCase();
+  const trimmed = url.trim().toLowerCase();
+  if (!trimmed) return "";
+
+  try {
+    const parsed = new URL(
+      trimmed.startsWith("http") ? trimmed : `https://${trimmed}`
+    );
+    return parsed.hostname;
+  } catch {
+    return "";
+  }
 }

--- a/src/theme-toggle/theme-init.js
+++ b/src/theme-toggle/theme-init.js
@@ -1,17 +1,44 @@
+const SECRET_KEY = "focus-blocker-key";
+
+function xor(str) {
+  let result = "";
+  for (let i = 0; i < str.length; i++) {
+    result += String.fromCharCode(
+      str.charCodeAt(i) ^ SECRET_KEY.charCodeAt(i % SECRET_KEY.length)
+    );
+  }
+  return result;
+}
+
+function decrypt(text) {
+  return xor(atob(text));
+}
+
 (function () {
   try {
-    const storedTheme = localStorage.getItem("focus-blocker-theme");
-    const systemPrefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
-    const theme = storedTheme || (systemPrefersDark ? "dark" : "light");
-    if (theme === "dark") {
-      document.documentElement.setAttribute("data-theme", "dark");
-      const meta = document.querySelector('meta[name="theme-color"]');
-      if (meta) meta.setAttribute("content", "#000000");
-    } else {
-      document.documentElement.removeAttribute("data-theme");
-      const meta = document.querySelector('meta[name="theme-color"]');
-      if (meta) meta.setAttribute("content", "#ffffff");
-    }
+    chrome.storage.local.get("focus-blocker-theme", (data) => {
+      let storedTheme = data["focus-blocker-theme"];
+      if (storedTheme) {
+        try {
+          storedTheme = decrypt(storedTheme);
+        } catch {
+          storedTheme = null;
+        }
+      }
+      const systemPrefersDark = window.matchMedia(
+        "(prefers-color-scheme: dark)"
+      ).matches;
+      const theme = storedTheme || (systemPrefersDark ? "dark" : "light");
+      if (theme === "dark") {
+        document.documentElement.setAttribute("data-theme", "dark");
+        const meta = document.querySelector('meta[name="theme-color"]');
+        if (meta) meta.setAttribute("content", "#000000");
+      } else {
+        document.documentElement.removeAttribute("data-theme");
+        const meta = document.querySelector('meta[name="theme-color"]');
+        if (meta) meta.setAttribute("content", "#ffffff");
+      }
+    });
   } catch (e) {
     console.warn("Theme init failed:", e);
   }


### PR DESCRIPTION
## Summary
- Request host permissions only for specific origins and drop unsafe CSP
- Sanitize and validate user-provided URLs before creating blocking rules
- Encrypt stored preferences and remove external font dependency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e3adad7548322a954ad0cbabea5b8