### PR TITLE
fix: ensure Opera API fallback

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,6 @@
 const SECRET_KEY = "focus-blocker-key";
-const browser = globalThis.browser || globalThis.chrome;
+const browser =
+  globalThis.browser || globalThis.chrome || globalThis.opera || globalThis.opr;
 
 function xor(str) {
   let result = "";

--- a/src/options/storage.js
+++ b/src/options/storage.js
@@ -1,4 +1,5 @@
-const browser = globalThis.browser || globalThis.chrome;
+const browser =
+  globalThis.browser || globalThis.chrome || globalThis.opera || globalThis.opr;
 
 function xor(str) {
   let result = "";


### PR DESCRIPTION
## Summary
- handle Opera's global API objects so extension works in its browser

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68a852060e9c8322bd16fb141362b989